### PR TITLE
Fix indentation errors in AtCoder scripts

### DIFF
--- a/atcoder/ABC/401/d.py
+++ b/atcoder/ABC/401/d.py
@@ -25,6 +25,7 @@ for i in S:
         if S.count(0) == K:
             S.replace(0, 1)
         else:
+            pass
 
 
 

--- a/atcoder/ABC/402/d.py
+++ b/atcoder/ABC/402/d.py
@@ -25,6 +25,7 @@ for i in S:
         if S.count(0) == K:
             S.replace(0, 1)
         else:
+            pass
 
 
 

--- a/atcoder/ABC/403/d.py
+++ b/atcoder/ABC/403/d.py
@@ -25,6 +25,7 @@ for i in S:
         if S.count(0) == K:
             S.replace(0, 1)
         else:
+            pass
 
 
 

--- a/atcoder/ABC/404/d.py
+++ b/atcoder/ABC/404/d.py
@@ -25,6 +25,7 @@ for i in S:
         if S.count(0) == K:
             S.replace(0, 1)
         else:
+            pass
 
 
 


### PR DESCRIPTION
## Summary
- fix syntax errors in multiple AtCoder `d.py` scripts

## Testing
- `python3 -m py_compile atcoder/ABC/401/d.py`
- `python3 -m py_compile atcoder/ABC/402/d.py`
- `python3 -m py_compile atcoder/ABC/403/d.py`
- `python3 -m py_compile atcoder/ABC/404/d.py`
- `xargs -a pyfiles.txt -I {} python3 -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_6845aead68c0832baec166f2a94dbbb4